### PR TITLE
fix(ui): remove white tint from fab_create_post

### DIFF
--- a/app/src/main/res/layout/fragment_news.xml
+++ b/app/src/main/res/layout/fragment_news.xml
@@ -36,7 +36,6 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
         android:layout_margin="16dp"
-        android:src="@android:drawable/ic_input_add"
-        app:tint="@android:color/white" />
+        android:src="@android:drawable/ic_input_add" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
теперь плюсик внутри кнопки создания поста светлый только на тёмной теме